### PR TITLE
Bump Elixir to v1.11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1.7
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -88,7 +88,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1.7
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -112,7 +112,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1.7
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -127,7 +127,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1.7
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -163,7 +163,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1.7
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push]
 
 env:
   otp-version: "23.2.3"
-  elixir-version: "1.11.2"
+  elixir-version: "1.11.4"
   python-version: "3.8"
   node-version: "14"
 


### PR DESCRIPTION
- [x] Bump Elixir to `v1.11.4`
- [x] Switch `setup-elixir` action to `setup-beam` since it's been renamed
- [x] Bust Dialyzer CI PLT cache in the process to fix problems with the updated action